### PR TITLE
Fixed bug in NumberFormatter to always update TextField.text

### DIFF
--- a/TextFieldBehavior/NumericTextField.swift
+++ b/TextFieldBehavior/NumericTextField.swift
@@ -88,6 +88,9 @@ struct NumericTextField<T>: UIViewRepresentable {
             
             if let newValue = valueContainer as? T,
                errorContainer == nil {
+                if let stringVal = formatter.string(for: value) {
+                    textField.text = stringVal
+                }
                 self.value = newValue
             }
         }


### PR DESCRIPTION
Fixed bug in NumberFormatter to always update TextField.text even when edits such as 10.00 -> 10.0 don't change the underlying value.